### PR TITLE
Adding empty array as default param

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -18,7 +18,7 @@ abstract class ApiClient
         return $this->requestCount;
     }
 
-    public function makeCall($endpoint, array $params)
+    public function makeCall($endpoint, array $params = [])
     {
         // remove empty params
         $params = array_filter($params, function ($var) {


### PR DESCRIPTION
No parameters is a valid request, so I added an empty array so I don't have to provide `[]` as the second parameter.
